### PR TITLE
add smart_open as dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,18 @@
 from setuptools import setup
 
-setup(name='negspy',
-      version='0.3.1',
-      description='Python NGS tools',
-      author='Peter Kerpedjiev',
-      author_email='pkerpedjiev@gmail.com',
-      url='',
-      packages=['negspy'],
-      package_data={'negspy': ['data/*/chromInfo.txt', 'data/*/chromOrder.txt']},
-      scripts=['scripts/chr_pos_to_genome_pos.py', 'scripts/make_triangular.py', 'scripts/create_chrominfo.py']
-
-     )
+setup(
+    name="negspy",
+    version="0.3.1",
+    description="Python NGS tools",
+    author="Peter Kerpedjiev",
+    author_email="pkerpedjiev@gmail.com",
+    url="",
+    packages=["negspy"],
+    package_data={"negspy": ["data/*/chromInfo.txt", "data/*/chromOrder.txt"]},
+    install_requires=["smart_open"],
+    scripts=[
+        "scripts/chr_pos_to_genome_pos.py",
+        "scripts/make_triangular.py",
+        "scripts/create_chrominfo.py",
+    ],
+)


### PR DESCRIPTION
smart_open was added as a hard import in negspy/coordinates.py in v0.3.0 (commit "Use smart_open instead of regular open"), but was never added to install_requires in setup.py. This means any package that depends on negspy (e.g. vitessce) will install successfully but fail at import time with ModuleNotFoundError: No module named 'smart_open'.

This PR adds smart_open to install_requires to fix the broken transitive dependency.

Fixes #7 